### PR TITLE
[BUGFIX] Datetime constraint should only be unset if event restrictio…

### DIFF
--- a/Classes/Hooks/AbstractDemandedRepository.php
+++ b/Classes/Hooks/AbstractDemandedRepository.php
@@ -44,14 +44,15 @@ class AbstractDemandedRepository {
 	 * @return void
 	 */
 	protected function updateEventConstraints(Demand $demand, $respectEnableFields, \TYPO3\CMS\Extbase\Persistence\QueryInterface $query, array &$constraints) {
-		// reset datetime constraint
-		unset($constraints['datetime']);
 
 		$eventRestriction = $demand->getEventRestriction();
 
 		if ($eventRestriction === Demand::EVENT_RESTRICTION_NO_EVENTS) {
 			$constraints[] = $query->equals('isEvent', 0);
 		} elseif ($eventRestriction === Demand::EVENT_RESTRICTION_ONLY_EVENTS) {
+			// reset datetime constraint
+			unset($constraints['datetime']);
+
 			$constraints[] = $query->equals('isEvent', 1);
 
 			$dateField = $demand->getDateField();


### PR DESCRIPTION
…n is set (refs #4)

Currently, the datetime constraint from EXT:news is unset in any case
EXT:eventnews is used, but it should only be unset if only events are
requested.
