### PR TITLE
"news only" save default setting

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,4 +1,8 @@
 
 plugin.tx_news.settings {
 	demandClass = GeorgRinger\Eventnews\Domain\Model\Dto\Demand
+	
+	# Unless otherwise flexformed restrict all news plugins to display "news only"
+	eventRestriction = 2
+	overrideFlexformSettingsIfEmpty := addToList(eventRestriction)
 }


### PR DESCRIPTION
Unless otherwise flexformed should all news plugins preset to display "news only", see #8 
